### PR TITLE
svg loading feedback and abortion control

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,7 +121,7 @@
 
     <div id="editor">// Press ALT + ENTER to run.
 
-for(var i=0; i&lt;50000; i++) {
+for(var i=0; i&lt;200000; i++) {
   turnLeft(Math.random());
   moveForward(1);
 }


### PR DESCRIPTION
Most of the calculation time is spend rendering/loading the SVG.
Unfortunately aborting SVG loading once it started is not possible.

Rewriting the URL while it is being loaded would result in undefined
behaviour, probably even locking the browser.

To prevent this from happening at all, we check if the SVG is loaded
before starting the turtle worker inside the testCode function.
- loading feedback in the info field.
- disabled run/abort button during loading
- prevent running while loading
